### PR TITLE
Remove WordPress dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Parameter | Default value | Description
 ------------ | ------------- | ------------
 **directory** | ```null``` | Path of your project. Probably use **```__DIR__```** here
 **namespace_prefix** | ```null``` | Namespace prefix of your project
-**classes_dir** | ```''``` | Relative path of the directory containing all your classes **(optional)**.
+**classes_dir** | ```array( '.', 'vendor' )``` | Relative path of the directory containing all your classes. Accepts string or array of strings. Defaults to **`directory`** parameter and the vendor subdirectory.  **(optional)**.
 **lowercase** | ```array('file')``` | If you want to lowercase just the file or folders too. It accepts an array with two possible values: **'file', 'folders'**.
 **underscore_to_hyphen** | ```array('file')``` | If you want to convert underscores to hyphens. It accepts an array with two possible values: **'file',  'folders'**.
 **prepend_class** | ```true``` | If you want to prepend 'class-' before files

--- a/src/WP_Namespace_Autoloader.php
+++ b/src/WP_Namespace_Autoloader.php
@@ -36,7 +36,7 @@ if ( ! class_exists( '\Pablo_Pacheco\WP_Namespace_Autoloader\WP_Namespace_Autolo
 				'lowercase'            => array( 'file' ), // 'file' | folders
 				'underscore_to_hyphen' => array( 'file' ), // 'file' | folders
 				'prepend_class'        => true,
-				'classes_dir'          => '',
+				'classes_dir'          => array( '.', 'vendor' ),
 				'debug'                => false,
 			) );
 

--- a/src/WP_Namespace_Autoloader.php
+++ b/src/WP_Namespace_Autoloader.php
@@ -26,7 +26,7 @@ if ( ! class_exists( '\Pablo_Pacheco\WP_Namespace_Autoloader\WP_Namespace_Autolo
 		 * @type array         $lowercase            If you want to lowercase. It accepts an array with two possible values: 'file' | 'folders'
 		 * @type array         $underscore_to_hyphen If you want to convert underscores to hyphens. It accepts an array with two possible values: 'file' | 'folders'
 		 * @type boolean       $prepend_class        If you want to prepend 'class-' before files
-		 * @type string        $classes_dir          Name of the directory containing all your classes (optional).
+		 * @type string|array  $classes_dir          Name of the directories containing all your classes (optional).
 		 * }
 		 */
 		function __construct( $args = array() ) {
@@ -76,31 +76,55 @@ if ( ! class_exists( '\Pablo_Pacheco\WP_Namespace_Autoloader\WP_Namespace_Autolo
 		 */
 		public function autoload( $class ) {
 			if ( $this->need_to_autoload( $class ) ) {
-				$file = $this->convert_class_to_file( $class );
-				if ( is_string( $file ) && file_exists( $file ) ) {
-					require_once $file;
-				} else {
-					$args = $this->get_args();
-					if ( $args['debug'] ) {
-						error_log( 'WP Namespace Autoloader could not load file: ' . print_r( $file, true ) );
+				$file_paths = $this->convert_class_to_file( $class );
+				foreach( $file_paths as $file ) {
+					if ( file_exists( $file ) ) {
+						require_once $file;
+						return;
 					}
 				}
+
+				$args = $this->get_args();
+				if ( $args['debug'] ) {
+					error_log( 'WP Namespace Autoloader could not load file: ' . print_r( $file_paths, true ) );
+				}
+
 			}
 		}
 
 		/**
-		 * Gets full path of directory containing all classes
+		 * Gets full path of directories containing classes, using the $args['classes_dir'] input argument.
 		 *
-		 * @return string
+		 * @return string|array
 		 */
 		private function get_dir() {
 			$args = $this->get_args();
-			$dir  = $this->sanitize_file_path( $args['classes_dir'] );
 
-			// Directory containing all classes
-			$classes_dir = empty( $dir ) ? '' : rtrim( $dir, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR;
+			if( is_array( $args['classes_dir'] ) ) {
 
-			return untrailingslashit( $args['directory'] ) . DIRECTORY_SEPARATOR . $classes_dir;
+				$dirs = array();
+
+				foreach( $args['classes_dir']  as $classes_dir ) {
+
+					$dir = $this->sanitize_file_path( $classes_dir );
+
+					$classes_dir = empty( $dir ) ? '' : rtrim( $dir, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR;
+
+					$dirs[] = untrailingslashit( $args['directory'] ) . DIRECTORY_SEPARATOR . $classes_dir;
+				}
+
+				return $dirs;
+
+			} else {
+
+				$dir  = $this->sanitize_file_path( $args['classes_dir'] );
+
+				// Directory containing all classes
+				$classes_dir = empty( $dir ) ? '' : rtrim( $dir, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR;
+
+				return untrailingslashit( $args['directory'] ) . DIRECTORY_SEPARATOR . $classes_dir;
+			}
+
 		}
 
 		/**
@@ -214,20 +238,33 @@ if ( ! class_exists( '\Pablo_Pacheco\WP_Namespace_Autoloader\WP_Namespace_Autolo
 		 * @param string $class
 		 * @param bool   $check_loading_need
 		 *
-		 * @return bool|string
+		 * @return array();
 		 */
 		public function convert_class_to_file( $class, $check_loading_need = false ) {
 			if ( $check_loading_need ) {
 				if ( ! $this->need_to_autoload( $class ) ) {
-					return false;
+					return array();
 				}
 			}
 
-			$dir                 = $this->get_dir();
 			$namespace_file_path = $this->get_namespace_file_path( $class );
 			$final_file          = $this->get_file_applying_wp_standards( $class );
 
-			return $dir . $namespace_file_path . $final_file;
+			$class_files = array();
+
+			$dir                 = $this->get_dir();
+
+			if( is_array( $dir ) ) {
+
+				foreach( $dir as $class_dir ) {
+					$class_files[] = $class_dir . $namespace_file_path . $final_file;
+				}
+
+			} else {
+				$class_files[] = $dir . $namespace_file_path . $final_file;
+			}
+
+			return $class_files;
 		}
 
 		/**

--- a/src/WP_Namespace_Autoloader.php
+++ b/src/WP_Namespace_Autoloader.php
@@ -30,7 +30,7 @@ if ( ! class_exists( '\Pablo_Pacheco\WP_Namespace_Autoloader\WP_Namespace_Autolo
 		 * }
 		 */
 		function __construct( $args = array() ) {
-			$args = wp_parse_args( $args, array(
+			$defaults = array(
 				'directory'            => null,
 				'namespace_prefix'     => null,
 				'lowercase'            => array( 'file' ), // 'file' | folders
@@ -38,9 +38,11 @@ if ( ! class_exists( '\Pablo_Pacheco\WP_Namespace_Autoloader\WP_Namespace_Autolo
 				'prepend_class'        => true,
 				'classes_dir'          => '',
 				'debug'                => false,
-			) );
+			);
 
-			$this->set_args( $args );
+			$parsed_args = array_merge( $defaults, $args );
+
+			$this->set_args( $parsed_args );
 		}
 
 		/**

--- a/src/WP_Namespace_Autoloader.php
+++ b/src/WP_Namespace_Autoloader.php
@@ -56,7 +56,7 @@ if ( ! class_exists( '\Pablo_Pacheco\WP_Namespace_Autoloader\WP_Namespace_Autolo
 			$args      = $this->get_args();
 			$namespace = $args['namespace_prefix'];
 
-			if ( ! class_exists( $class ) ) {
+			if ( ! class_exists( $class ) && ! interface_exists( $class ) ) {
 
 				if ( false !== strpos( $class, $namespace ) ) {
 					if ( ! class_exists( $class ) ) {
@@ -170,12 +170,20 @@ if ( ! class_exists( '\Pablo_Pacheco\WP_Namespace_Autoloader\WP_Namespace_Autolo
 				$final_file = str_replace( array( '_', "\0" ), array( '-', '', ), $final_file );
 			}
 
-			$final_file .= '.php';
-
 			// Prepend class
 			if ( $args['prepend_class'] ) {
-				$final_file = 'class-' . $final_file;
+				$prepended = preg_replace( '/(.*)-interface$/', 'interface-$1', $final_file );
+				$prepended = preg_replace( '/(.*)-abstract$/', 'abstract-$1', $prepended );
+
+				// If no changes were made when looking for interfaces and abstract classes, prepend "class-".
+				if ( $prepended === $final_file ) {
+					$final_file = 'class-' . $final_file;
+				} else {
+					$final_file = $prepended;
+				}
 			}
+
+			$final_file .= '.php';
 
 			return $final_file;
 		}

--- a/src/WP_Namespace_Autoloader.php
+++ b/src/WP_Namespace_Autoloader.php
@@ -102,7 +102,7 @@ if ( ! class_exists( '\Pablo_Pacheco\WP_Namespace_Autoloader\WP_Namespace_Autolo
 			// Directory containing all classes
 			$classes_dir = empty( $dir ) ? '' : rtrim( $dir, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR;
 
-			return untrailingslashit( $args['directory'] ) . DIRECTORY_SEPARATOR . $classes_dir;
+			return rtrim( $args['directory'], '/\\' ) . DIRECTORY_SEPARATOR . $classes_dir;
 		}
 
 		/**


### PR DESCRIPTION
In order to use WP_Mock for unit tests, I replaced the WordPress functions being used with the content from the function definitions.

No breaking changes.