### PR TITLE
Replace untrailingslashit with rtrim

### DIFF
--- a/src/WP_Namespace_Autoloader.php
+++ b/src/WP_Namespace_Autoloader.php
@@ -112,7 +112,7 @@ if ( ! class_exists( '\Pablo_Pacheco\WP_Namespace_Autoloader\WP_Namespace_Autolo
 
 					$classes_dir = empty( $dir ) ? '' : rtrim( $dir, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR;
 
-					$dirs[] = untrailingslashit( $args['directory'] ) . DIRECTORY_SEPARATOR . $classes_dir;
+					$dirs[] = rtrim( $args['directory'], '/\\' ) . DIRECTORY_SEPARATOR . $classes_dir;
 				}
 
 				return $dirs;


### PR DESCRIPTION
When I made the earlier PRs to you, they were all written so they could be individually merged against master, but when merged together there was a use of untrailingslashit that was added in one PR so not removed in the other!