### PR TITLE
[Bugfix] Namespace prefix replaced multiple times if there are multiple occurrences 

### DIFF
--- a/src/WP_Namespace_Autoloader.php
+++ b/src/WP_Namespace_Autoloader.php
@@ -170,7 +170,7 @@ if ( ! class_exists( '\Pablo_Pacheco\WP_Namespace_Autoloader\WP_Namespace_Autolo
 			$sanitized_namespace_prefix = $this->sanitize_namespace( $namespace_prefix, true );
 
 			// Removes prefix from class namespace.
-			$namespace_without_prefix = preg_replace( '/' . $sanitized_namespace_prefix . '/', '', $sanitized_class, 1 );
+			$namespace_without_prefix = preg_replace( '/' . $sanitized_namespace_prefix . '\/', '', $sanitized_class, 1 );
 
 			// Gets namespace file path.
 			$namespaces_without_prefix_arr = explode( '\\', $namespace_without_prefix );

--- a/src/WP_Namespace_Autoloader.php
+++ b/src/WP_Namespace_Autoloader.php
@@ -170,7 +170,7 @@ if ( ! class_exists( '\Pablo_Pacheco\WP_Namespace_Autoloader\WP_Namespace_Autolo
 			$sanitized_namespace_prefix = $this->sanitize_namespace( $namespace_prefix, true );
 
 			// Removes prefix from class namespace.
-			$namespace_without_prefix = str_replace( $sanitized_namespace_prefix, '', $sanitized_class );
+			$namespace_without_prefix = preg_replace( '/' . $sanitized_namespace_prefix . '/', '', $sanitized_class, 1 );
 
 			// Gets namespace file path.
 			$namespaces_without_prefix_arr = explode( '\\', $namespace_without_prefix );


### PR DESCRIPTION
I found and fixed a bug where the namespace prefix gets removed multiple times if there are multiple occurrences of that prefix in the namespace. For instance:

Prefix = Organization;
Namespace = Organization\Clients\Organization\Api_Client

Result before bugfix: Clients\Api_Client
Result after bugfix: Clients\Organization\Api_Client

[Sandbox snippet of solution](https://onlinephp.io/?s=jZBdasMwEISfI9AdlmBQAiYhz24ppQfIBQxCkdexiCMLSaYlJXfvSia_tNAHwaIZzc6nlzfXOc44a0eroxksBGVNNCeUVh0xOKVxAcV1LqFQTSN3Sh9Cr0IHr9CqPiAs4ZuzmWlh8eyYlJnHOHoL0ZvjY6Coa0GmVR4qsp4BU-J_XmU7Z-dEUDiPrfmiRvOt3xPFSSWgeXUv_Uo3qSVtGTFnFhdbIzUxBHoo7jPrj96gjaF-uHx3Rk5CwriVlZ8mdsMY5bUFDXvp0fV5v1gLor90TP-wFgRI57lHCZvcjzPU3QB_rqh-AA%2C%2C&v=8.1.10)
